### PR TITLE
Demo CLI (one fake fight) + tests

### DIFF
--- a/__main__.py
+++ b/__main__.py
@@ -1,0 +1,15 @@
+"""Entry point for ``python -m mutants``."""
+
+from __future__ import annotations
+
+from .drivers.cli import cli
+
+
+def main() -> None:  # pragma: no cover - thin wrapper
+    """Execute the command line interface."""
+
+    cli(standalone_mode=False)
+
+
+if __name__ == "__main__":  # pragma: no cover - manual invocation
+    main()

--- a/agents.md
+++ b/agents.md
@@ -11,6 +11,9 @@ Recreate the BBS game “Mutants” as a modular Python project. For proof-of-co
 - Run tests: `pytest -q`
 - Format/lint: `ruff format .` and `ruff check .`
 
+## Guardrails
+- No to-hit rolls or random damage; damage is flat per rules.
+
 ## Project Structure (target)
 mutants/
   engine/          # rng, rules, statuses, effects, combat, ai, loot, serialization

--- a/drivers/cli.py
+++ b/drivers/cli.py
@@ -1,23 +1,52 @@
-"""Command line interface for a placeholder encounter."""
+"""Command line interface for the Mutants demo."""
 
 from __future__ import annotations
 
 import click
 
-from engine.rng import RNG
+try:  # pragma: no cover - fallback for direct execution
+    from ..engine.rng import RNG
+except ImportError:  # pragma: no cover - when repository root on sys.path
+    from engine.rng import RNG
 
 
-@click.command()
-def main() -> None:
-    """Run a tiny demo encounter.
+@click.group()
+def cli() -> None:
+    """Mutants command line tools."""
 
-    For now the CLI simply rolls a six-sided die and prints the result to show
-    that the project is wired up correctly.
+
+@cli.command()
+def demo() -> int:
+    """Run a tiny deterministic demo encounter.
+
+    The encounter rolls initiative using a fixed seed and then performs
+    three placeholder rounds.  This command is mechanics-neutral and exists
+    solely to smoke-test the CLI wiring.
     """
 
-    rng = RNG()
-    roll = rng.die(6)
-    click.echo(f"A mutant appears! You roll a {roll}.")
+    rng = RNG(seed=42)
+
+    click.echo("Rolling initiative...")
+    player_init = rng.die(20)
+    mutant_init = rng.die(20)
+    click.echo(f"You roll {player_init} for initiative.")
+    click.echo(f"The mutant rolls {mutant_init}.")
+
+    if player_init >= mutant_init:
+        click.echo("You act first!")
+    else:
+        click.echo("The mutant acts first!")
+
+    for round_number in range(1, 4):
+        click.echo(f"Round {round_number}: demo action.")
+
+    return 0
+
+
+def main() -> None:  # pragma: no cover - thin wrapper
+    """Entrypoint used by console scripts."""
+
+    cli(standalone_mode=False)
 
 
 if __name__ == "__main__":  # pragma: no cover - manual invocation

--- a/tests/test_cli_demo.py
+++ b/tests/test_cli_demo.py
@@ -1,0 +1,19 @@
+import sys
+from pathlib import Path
+
+sys.path.append(str(Path(__file__).resolve().parents[1]))
+
+from click.testing import CliRunner
+
+from drivers.cli import cli
+
+
+def test_demo_command_has_no_hit_or_miss() -> None:
+    runner = CliRunner()
+    result = runner.invoke(cli, ["demo"])
+
+    assert result.exit_code == 0
+    output_lower = result.output.lower()
+    assert output_lower.strip()  # some output exists
+    assert "hit" not in output_lower
+    assert "miss" not in output_lower


### PR DESCRIPTION
## Summary
- Make demo CLI mechanics-neutral with placeholder rounds
- Add guardrail forbidding to-hit rolls and random damage
- Test CLI output avoids "hit"/"miss" wording

## Testing
- `ruff format .`
- `ruff check .`
- `pytest -q`


------
https://chatgpt.com/codex/tasks/task_e_68b58564fc00832ba40dd9d6abdddc9a